### PR TITLE
Implement stale management for Issues and PRs.

### DIFF
--- a/.github/workflows/mark_stale.yml
+++ b/.github/workflows/mark_stale.yml
@@ -1,0 +1,47 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  # Scheduled to run at 1.30 UTC everyday
+  - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      actions: write
+
+    steps:
+    - uses: actions/stale@v9
+      with:
+        days-before-issue-stale: 7
+        days-before-issue-close: 7
+        stale-issue-label: "status:stale"
+        close-issue-reason: completed
+        any-of-labels: "status:awaiting user response,status:more data needed"
+        stale-issue-message: >
+          Marking this issue as stale since it has been open for 7 days with no activity.
+          This issue will be closed if no further activity occurs.
+        close-issue-message: >
+          This issue was closed because it has been inactive for 14 days.
+          Please post a new issue if you need further assistance. Thanks!
+        days-before-pr-stale: 14
+        days-before-pr-close: 14
+        stale-pr-label: "status:stale"
+        stale-pr-message: >
+          Marking this pull request as stale since it has been open for 14 days with no activity.
+          This PR will be closed if no further activity occurs.
+        close-pr-message: >
+          This pull request was closed because it has been inactive for 28 days.
+          Please open a new pull request if you need further assistance. Thanks!
+        # Label that can be assigned to issues to exclude them from being marked as stale
+        exempt-issue-labels: 'override-stale'
+        # Label that can be assigned to PRs to exclude them from being marked as stale
+        exempt-pr-labels: "override-stale"


### PR DESCRIPTION
Implement stale management for Issues and PRs. 

If labels are present **'status:awaiting user response'** and **'status:more data needed'** are present in the issue and it is inactive for 7 days for PRs and 14 days for issues, then a "status:stale" label will be added. After 7 additional days of inactivity for PRs and 14 days for issues, they will be closed.