### PR TITLE
updating pyproject.toml to explicitly only allow supported torch vers…

### DIFF
--- a/src/server/package/pyproject.toml
+++ b/src/server/package/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "requests",
   "termcolor",
   "typing-extensions",
-  "torch",
+  "torch >= 2.2",
   "numpy",
 ]
 


### PR DESCRIPTION
…ions

It's in the wiki so let's make this explicit. Fixes: https://github.com/google-ai-edge/model-explorer/issues/104