### PR TITLE
Fix ExportedProgram display when tensor is None

### DIFF
--- a/src/server/package/src/model_explorer/pytorch_exported_program_adater_impl.py
+++ b/src/server/package/src/model_explorer/pytorch_exported_program_adater_impl.py
@@ -178,14 +178,15 @@ class PytorchExportedProgramAdapterImpl:
       tensor_spec = self.inputs_map.get(fx_node.name)
       if tensor_spec:
         node.attrs.append(KeyValue(key='target', value=str(tensor_spec[0])))
-        node.attrs.append(
-            KeyValue(
-                key='__value',
-                value=self.print_tensor(
-                    tensor_spec[1], self.settings['const_element_count_limit']
-                ),
-            )
-        )
+        if (tensor := tensor_spec[1]) is not None:
+          node.attrs.append(
+              KeyValue(
+                  key='__value',
+                  value=self.print_tensor(
+                      tensor, self.settings['const_element_count_limit']
+                  ),
+              )
+          )
 
   def add_outputs_metadata(self, fx_node: torch.fx.node.Node, node: GraphNode):
     out_vals = fx_node.meta.get('val')


### PR DESCRIPTION
Without the fix I get the following error message:

```pytb
Traceback (most recent call last):
  File "/home/justinchu/anaconda3/envs/onnx/lib/python3.11/site-packages/model_explorer/server.py", line 208, in send_command
    resp = extension_manager.run_cmd(request.json)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/justinchu/anaconda3/envs/onnx/lib/python3.11/site-packages/model_explorer/extension_manager.py", line 82, in run_cmd
    resp = self.adapter_runner.run_adapter(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/justinchu/anaconda3/envs/onnx/lib/python3.11/site-packages/model_explorer/adapter_runner.py", line 37, in run_adapter
    return fn(modelPath, cmd['settings'])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/justinchu/anaconda3/envs/onnx/lib/python3.11/site-packages/model_explorer/builtin_pytorch_exportedprogram_adapter.py", line 44, in convert
    return PytorchExportedProgramAdapterImpl(ep, settings).convert()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/justinchu/anaconda3/envs/onnx/lib/python3.11/site-packages/model_explorer/pytorch_exported_program_adater_impl.py", line 237, in convert
    return {'graphs': [self.create_graph()]}
                       ^^^^^^^^^^^^^^^^^^^
  File "/home/justinchu/anaconda3/envs/onnx/lib/python3.11/site-packages/model_explorer/pytorch_exported_program_adater_impl.py", line 233, in create_graph
    graph.nodes.append(self.create_node(node))
                       ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/justinchu/anaconda3/envs/onnx/lib/python3.11/site-packages/model_explorer/pytorch_exported_program_adater_impl.py", line 226, in create_node
    self.add_node_attrs(fx_node, node)
  File "/home/justinchu/anaconda3/envs/onnx/lib/python3.11/site-packages/model_explorer/pytorch_exported_program_adater_impl.py", line 184, in add_node_attrs
    value=self.print_tensor(
          ^^^^^^^^^^^^^^^^^^
  File "/home/justinchu/anaconda3/envs/onnx/lib/python3.11/site-packages/model_explorer/pytorch_exported_program_adater_impl.py", line 154, in print_tensor
    shape = tensor.shape
            ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'shape'
```

cc @pkgoogle @jinjingforever 