### PR TITLE
Add a send_command GET request handler for handling requests sent in internal colab

### DIFF
--- a/src/server/package/src/model_explorer/server.py
+++ b/src/server/package/src/model_explorer/server.py
@@ -169,10 +169,10 @@ def _js(script):
 
 def _is_internal_colab() -> bool:
   return (
-      "BORG_TASK_HANDLE" in os.environ
-      or "X20_HOME" in os.environ
-      or "UNITTEST_ON_BORG" in os.environ
-      or "google3.research.colab.lib" in sys.modules
+      'BORG_TASK_HANDLE' in os.environ
+      or 'X20_HOME' in os.environ
+      or 'UNITTEST_ON_BORG' in os.environ
+      or 'google3.research.colab.lib' in sys.modules
   )
 
 


### PR DESCRIPTION
Also add a url parameter to tell the web app whether it is running in internal colab or not.