### PR TITLE
Make the app build script also build and copy python deps

### DIFF
--- a/src/electron/app/build.sh
+++ b/src/electron/app/build.sh
@@ -28,6 +28,15 @@ echo '#### Install packages'
 
 npm install
 
+# Build the python server
+SERVER_DIR="model_explorer_server"
+if [ -d "$SERVER_DIR" ]; then rm -r $SERVER_DIR; fi
+mkdir $SERVER_DIR
+cd ../pyinstaller/
+./build.sh
+mv ./venv/lib/python*/site-packages/model_explorer/dist/model_explorer/* ../app/model_explorer_server
+cd -
+
 # Build and package electron app.
 echo
 echo '#### Build and package electon app'

--- a/src/electron/app/package-lock.json
+++ b/src/electron/app/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "model_explorer_electron",
       "version": "0.0.1",
-      "license": "ISC",
+      "license": "Apache-2.0",
       "dependencies": {
         "electron-log": "5.2.0",
         "electron-squirrel-startup": "^1.0.1"

--- a/src/electron/pyinstaller/build.sh
+++ b/src/electron/pyinstaller/build.sh
@@ -16,17 +16,20 @@
 # Fail on any error.
 set -e
 
+# Remember current directory.
+SCRIPT_DIR="$(pwd)"
+
 # Check python version.
 echo
 echo '#### Check python version'
 
-python --version
+python3 --version
 
 # Create venv.
 echo
 echo '#### Create venv'
 
-python -m venv venv
+python3 -m venv venv
 source venv/bin/activate
 
 # Install packages.
@@ -38,9 +41,11 @@ pip install torch ai-edge-model-explorer pyinstaller model-explorer-onnx \
     --extra-index-url https://pypi.python.org/simple
 
 # Replace the model explorer code with the latest.
+# Move to 'model-explorer/src/electron/pyinstaller/venv/lib/python3.X/site-packages'
 cd venv/lib/python*/site-packages/
 rm -rf model_explorer
-cp -rf "${KOKORO_ARTIFACTS_DIR}/github/model-explorer/src/server/package/src/model_explorer" .
+# Copy 'model-explorer/src/server/package/src/model_explorer/'
+cp -rf "${SCRIPT_DIR}/../../server/package/src/model_explorer" .
 cd -
 
 # Run pyinstaller


### PR DESCRIPTION
This removes Kokoro as a dependency in the build process, making it easy to build in oss.

I'll need to update the kokoro scripts to account for this, although they probably still work (but are less efficient since they build python twice now).