### PR TITLE
Show pytorch adapter even if torch in not imported.

### DIFF
--- a/src/server/package/src/model_explorer/extension_manager.py
+++ b/src/server/package/src/model_explorer/extension_manager.py
@@ -19,11 +19,6 @@ from dataclasses import asdict
 from importlib import import_module
 from typing import Any, Dict, Union
 
-try:
-  import torch
-except ImportError:
-  torch = None
-
 from .adapter_runner import AdapterRunner
 from .consts import MODULE_NAME
 from .extension_class_processor import ExtensionClassProcessor
@@ -41,9 +36,7 @@ class ExtensionManager(object, metaclass=Singleton):
           '.builtin_tf_mlir_adapter',
           '.builtin_tf_direct_adapter',
           '.builtin_graphdef_adapter',
-      ]
-      + (['.builtin_pytorch_exportedprogram_adapter'] if torch else [])
-      + [
+          '.builtin_pytorch_exportedprogram_adapter',
           '.builtin_mlir_adapter',
       ]
   )

--- a/src/server/package/src/model_explorer/extension_manager.py
+++ b/src/server/package/src/model_explorer/extension_manager.py
@@ -29,17 +29,15 @@ from .utils import convert_adapter_response
 
 
 class ExtensionManager(object, metaclass=Singleton):
-  BUILTIN_ADAPTER_MODULES: list[str] = (
-      [
-          '.builtin_tflite_flatbuffer_adapter',
-          '.builtin_tflite_mlir_adapter',
-          '.builtin_tf_mlir_adapter',
-          '.builtin_tf_direct_adapter',
-          '.builtin_graphdef_adapter',
-          '.builtin_pytorch_exportedprogram_adapter',
-          '.builtin_mlir_adapter',
-      ]
-  )
+  BUILTIN_ADAPTER_MODULES: list[str] = [
+      '.builtin_tflite_flatbuffer_adapter',
+      '.builtin_tflite_mlir_adapter',
+      '.builtin_tf_mlir_adapter',
+      '.builtin_tf_direct_adapter',
+      '.builtin_graphdef_adapter',
+      '.builtin_pytorch_exportedprogram_adapter',
+      '.builtin_mlir_adapter',
+  ]
 
   CACHED_REGISTERED_EXTENSIONS: Dict[str, RegisteredExtension] = {}
 


### PR DESCRIPTION
Just realized that it is useful to show that the pytorch adapter is available even if torch is not imported so that users know we support pytorch. We will display 'torch not installed' error message when user actually uses the adapter.