### PR TITLE
Use permissive file perms for build output

### DIFF
--- a/src/electron/app/forge.config.js
+++ b/src/electron/app/forge.config.js
@@ -94,6 +94,13 @@ module.exports = {
     }),
   ],
   hooks: {
+    postPackage: async (forgeConfig, options) => {
+      // Ensure permissions for the built app are permissive enough to allow
+      // us to run the app after all its files are owned by root.
+      for (const outputPath of options.outputPaths) {
+        execSync(`chmod -R a+rx '${outputPath}'`);
+      }
+    },
     postMake: async (forgeConfig, makeResults) => {
       // Rename the packaged file name from "Model Explorer-xxx.zip" to
       // "model-explorer-xxx.zip".


### PR DESCRIPTION
When deb installs a package, root owns all that package's files. If we do not grant read and execute permissions on the files installed by the pakcage, the user will not be able to run the installed model explorer app.