### PR TITLE
Update workflow names and hosted runner version

### DIFF
--- a/.github/workflows/build_release_adapters.yml
+++ b/.github/workflows/build_release_adapters.yml
@@ -5,7 +5,7 @@
 # https://yaml-online-parser.appspot.com/
 #
 
-name: PyPI Build Release All Backend Adapters
+name: PyPI Build and Release All Built-in Adapters
 
 on:
   workflow_dispatch:
@@ -26,7 +26,7 @@ jobs:
       # some of them fail
       fail-fast: false
       matrix:
-        runner: [Linux_runner_8_core, macos-latest, ubuntu-24.04-arm]
+        runner: [Linux_runner_8_core, macos-latest, ubuntu-22.04-arm]
         python-version: ['3.9', '3.10', '3.11', '3.12']
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/build_single_adapter.yml
+++ b/.github/workflows/build_single_adapter.yml
@@ -5,7 +5,7 @@
 # https://yaml-online-parser.appspot.com/
 #
 
-name: PyPI Build Single Platform & Python Version Adapters
+name: Test Build Single PyPI Adapter
 
 on:
   workflow_dispatch:
@@ -18,7 +18,7 @@ on:
         options:
           - Linux_runner_8_core
           - macos-latest
-          - ubuntu-24.04-arm
+          - ubuntu-22.04-arm
 
       python-version:
         description: 'Python Version'


### PR DESCRIPTION
`ubuntu-24.04-arm` tend to be less stable and can sometimes cause failure due to lost connection. Updating to `ubuntu-22.04-arm` for better stability.