### PR TITLE
Add reference to VGF adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ instructions and check out its [demos](src/custom_element_demos/).
 ## Community-contributed adapters
 
 - ONNX Adapter: https://github.com/justinchuby/model-explorer-onnx
+- VGF Adapter: https://github.com/arm/vgf-adapter-model-explorer
 
 ## Contributions
 


### PR DESCRIPTION
Add reference to the adapter for VGF files for the [ML SDK for Vulkan®](https://github.com/arm/ai-ml-sdk-for-vulkan).