### PR TITLE
Update ME version and adapter version.

### DIFF
--- a/src/server/package/pyproject.toml
+++ b/src/server/package/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-edge-model-explorer"
-version = "0.1.26"
+version = "0.1.27"
 authors = [
   { name="Google LLC", email="opensource@google.com" },
 ]
@@ -19,7 +19,7 @@ dependencies = [
   "flask",
   "ipython",
   # Skip on windows.
-  "ai-edge-model-explorer-adapter == 0.1.12; sys_platform != 'win32'",
+  "ai-edge-model-explorer-adapter ~= 0.1.13; sys_platform != 'win32'",
   "packaging",
   "portpicker",
   "requests",


### PR DESCRIPTION
Also use "~=" to specify adapter version to make it work with all future 0.1.x adapter releases.

(The JS bundle has been updated in one of the previous PRs)