### PR TITLE
Fix custom element WorkerService to match init() refactor

### DIFF
--- a/src/ui/src/custom_element/worker_service.ts
+++ b/src/ui/src/custom_element/worker_service.ts
@@ -23,9 +23,12 @@ import {Injectable} from '@angular/core';
  */
 @Injectable()
 export class WorkerService {
-  readonly worker: Worker;
+  worker!: Worker;
 
-  constructor() {
+  init(onPortal: boolean) {
+    if (this.worker) {
+      this.worker.terminate();
+    }
     const workerScriptUrl =
       // tslint:disable-next-line:no-any
       (window as any)['modelExplorer'].workerScriptPath ?? 'worker.js';

--- a/src/ui/src/custom_element/worker_service.ts
+++ b/src/ui/src/custom_element/worker_service.ts
@@ -16,13 +16,13 @@
  * ==============================================================================
  */
 
-import {Injectable} from '@angular/core';
+import {Injectable, OnDestroy} from '@angular/core';
 
 /**
  * Service to manage web worker.
  */
 @Injectable()
-export class WorkerService {
+export class WorkerService implements OnDestroy {
   worker!: Worker;
 
   init(onPortal: boolean) {
@@ -33,5 +33,9 @@ export class WorkerService {
       // tslint:disable-next-line:no-any
       (window as any)['modelExplorer'].workerScriptPath ?? 'worker.js';
     this.worker = new Worker(workerScriptUrl);
+  }
+
+  ngOnDestroy() {
+    this.worker.terminate();
   }
 }


### PR DESCRIPTION
## Summary

- The `custom_element/worker_service.ts` (used via `fileReplacements` in `angular.json` during the `custom_element` build) was not updated when 49aa6a8 refactored `WorkerService` to use a lazy `init()` method instead of constructor initialization.
- This causes `ng build custom_element` to fail with `TS2339: Property 'init' does not exist on type 'WorkerService'`, which blocks npm package builds.

## Test plan

- [x] Run `ng build custom_element` — should succeed without TS errors
- [x] Run `npm run build-npm` — should produce the full npm package in `custom_element_npm/dist/`